### PR TITLE
Insert the form key place holder directly into the form key template

### DIFF
--- a/Phoenix/VarnishCache/Model/Core/Url.php
+++ b/Phoenix/VarnishCache/Model/Core/Url.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class Phoenix_VarnishCache_Model_Core_Url
+ *
+ * Rewrite the core/url model to replace the value of the form_key parameter with a place holder if it's added to a url.
+ * This will allow the cookie cutter javascript to replace it later.
+ */
+class Phoenix_VarnishCache_Model_Core_Url extends Mage_Core_Model_Url {
+
+    /**
+     * Build url by requested path and parameters
+     * Replaces any form key with a place holder
+     *
+     * @param string|null $routePath
+     * @param array|null $routeParams
+     * @return  string
+     */
+    public function getUrl($routePath = null, $routeParams = null) {
+        if (isset($routeParams['form_key'])) {
+            $routeParams['form_key'] = Phoenix_VarnishCache_Model_Observer::FORM_KEY_PLACEHOLDER;
+        }
+        return parent::getUrl($routePath, $routeParams);
+    }
+}

--- a/Phoenix/VarnishCache/Model/Observer.php
+++ b/Phoenix/VarnishCache/Model/Observer.php
@@ -423,8 +423,11 @@ class Phoenix_VarnishCache_Model_Observer
      * Replace dynamically generated formkey with a place holder
      * @param Varien_Event_Observer $observer
      */
-
     public function replaceFormkey($observer) {
+        /*
+         * This fix is redundant now because we're putting the placeholder into the formkey template directly.
+         * It is safe to leave here though to catch any form keys that may have bypassed the formkey template.
+         */
         $sessionKey = Mage::getSingleton('core/session')->getFormKey();
         $vbody = $observer->getResponse()->getBody();
         $observer->getResponse()->setBody(str_replace($sessionKey, self::FORM_KEY_PLACEHOLDER, $vbody ));

--- a/Phoenix/VarnishCache/etc/config.xml
+++ b/Phoenix/VarnishCache/etc/config.xml
@@ -34,6 +34,12 @@
             <varnishcache_resource_mysql4>
                 <class>Phoenix_VarnishCache_Model_Resource_Mysql4</class>
             </varnishcache_resource_mysql4>
+
+            <core>
+                <rewrite>
+                    <url>Phoenix_VarnishCache_Model_Core_Url</url>
+                </rewrite>
+            </core>
         </models>
         <helpers>
             <varnishcache>

--- a/frontend/base/default/layout/varnishcache.xml
+++ b/frontend/base/default/layout/varnishcache.xml
@@ -4,5 +4,9 @@
         <reference name="head">
             <block type="varnishcache/personalisationcookie" name="personalisationcookie" template="varnishcache/personalisationcookie.phtml" />
         </reference>
+
+        <reference name="formkey">
+            <action method="setTemplate"><template>varnishcache/formkey.phtml</template></action>
+        </reference>
     </default>
 </layout>

--- a/frontend/base/default/template/varnishcache/formkey.phtml
+++ b/frontend/base/default/template/varnishcache/formkey.phtml
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Replace the form key with the form key place holder
+ */
+?>
+<?php
+$formKeyEnabled = Mage::getStoreConfig(Phoenix_VarnishCache_Model_Observer::CONFIG_ENABLED_FORM_KEY);
+$formKey = $formKeyEnabled ? Phoenix_VarnishCache_Model_Observer::FORM_KEY_PLACEHOLDER : Mage::getSingleton('core/session')->getFormKey();
+?>
+<input name="form_key" type="hidden" value="<?php echo $formKey ?>" />


### PR DESCRIPTION
The current method to cookie cutter the form key has some issues. It attempts to search for the current users for key in the response body before it's returned. The issue is that the response body could contain form keys that were cached by previous users. This fix inserts the form key placeholder directly into the form key template so an actual form key is never cached.