### PR TITLE
Use isDispatched flag to avoid accessing sessions in setup scripts.

### DIFF
--- a/Phoenix/VarnishCache/Model/Control/Sitewide.php
+++ b/Phoenix/VarnishCache/Model/Control/Sitewide.php
@@ -36,10 +36,16 @@ class Phoenix_VarnishCache_Model_Control_Sitewide
             $oControl = $oHelper->getCacheControl();
             $oControl->clean($vDomains);
 
-            $this->_getSession()->addSuccess(
-            	Mage::helper('varnishcache')->__('Varnish cache has been purged.')
-            );
-
+            // Setup scripts may cause a cache purge, and we won't necessarily
+            // have a valid admin session while setup scripts are running.  All
+            // setup scripts are executed before the requests is dispatched, so
+            // if the request hasn't been dispatched yet, then we can assume
+            // setup scripts are running.
+            if (Mage::app()->getRequest()->isDispatched()) {
+                $this->_getSession()->addSuccess(
+                    Mage::helper('varnishcache')->__('Varnish cache has been purged.')
+                );
+            }
         }
         return $this;
     }


### PR DESCRIPTION
Model saves in setup scripts (especially VF_CustomMenu may cause session access which is an issue for unit test environments where sessions are not available (and setup scripts are too early in the process to mock them).