### PR TITLE
Observe customer_save_after event to update personalisation cookie

### DIFF
--- a/Phoenix/VarnishCache/etc/config.xml
+++ b/Phoenix/VarnishCache/etc/config.xml
@@ -285,6 +285,15 @@
                     </personalisation_cookie_update>
                 </observers>
             </customer_login>
+            <customer_save_after>
+                <observers>
+                    <personalisation_cookie_update>
+                        <type>singleton</type>
+                        <class>varnishcache/personalisationcookie</class>
+                        <method>updatePersonalisationCookie</method>
+                    </personalisation_cookie_update>
+                </observers>
+            </customer_save_after>
             <customer_logout>
                 <observers>
                     <personalisation_cookie_update>


### PR DESCRIPTION
Fixes issue when customer's name is used in frontend, and customer changes their name, but change is not reflected in cookie until next logout/login.