### PR TITLE
Override isAllowed to allow for proper permissions management.

### DIFF
--- a/Phoenix/VarnishCache/controllers/Adminhtml/VarnishCacheController.php
+++ b/Phoenix/VarnishCache/controllers/Adminhtml/VarnishCacheController.php
@@ -54,4 +54,9 @@ class Phoenix_VarnishCache_Adminhtml_VarnishCacheController
         }
         $this->_redirect('*/cache/index');
     }
+
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/cache');
+    }
 }


### PR DESCRIPTION
Note: reuses standard cache management ACL entry